### PR TITLE
Avoid duplicating primary header when extension=0

### DIFF
--- a/pyreduce/instruments/common.py
+++ b/pyreduce/instruments/common.py
@@ -227,7 +227,8 @@ class Instrument:
             extension = self.get_extension(h_prime, mode)
 
         header = hdu[extension].header
-        header.extend(h_prime, strip=False)
+        if extension != 0:
+            header.extend(h_prime, strip=False)
         header = self.add_header_info(header, mode)
         header["e_input"] = (os.path.basename(fname), "Original input filename")
 


### PR DESCRIPTION
Hi, I figured that when the data is loaded from the primary HDU (extension=0), the load_fits() method returns the primary header twice, which can be a bit confusing. This fixes it.
All the best,
René